### PR TITLE
F/processing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "ROSCO"]
 	path = ROSCO
 	url = https://github.com/NREL/ROSCO.git
+	branch = develop

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ cited as:
 For LaTeX users:
 
 ```
-    @misc{ROSCO_toolbox_2019,
+@misc{ROSCO_toolbox_2019,
     author = {NREL},
     title = {{ROSCO Toolbox. Version 0.1.0}},
     year = {2019},

--- a/ROSCO_toolbox/utilities.py
+++ b/ROSCO_toolbox/utilities.py
@@ -27,28 +27,17 @@ deg2rad = np.deg2rad(1)
 rpm2RadSec = 2.0*(np.pi)/60.0
 RadSec2rpm = 60/(2.0 * np.pi)
 
-class FAST_IO():
-    ''' 
-    A collection of utilities that may be useful for using the tools made accessbile in this toolbox with OpenFAST
-
-    A number of the file processing tools used here were provided by or modified from Emanual Branlard's weio library: https://github.com/ebranlard/weio. 
+class FAST_Plots():
+    '''
+    Some plotting utilities for OpenFAST data. 
 
     Methods:
-    --------
-    run_openfast
     plot_fast_out
-    load_output
-    load_ascii_output
-
+    plot_spectral
     '''
+
     def __init__(self):
         pass
-
-    def run_openfast(self,fast_dir,fastcall='OpenFAST',fastfile=None,chdir=False):
-        '''
-        Runs a openfast openfast simulation.
-        
-        ** Note ** 
         If running ROSCO, this function must be called from the same folder containing DISCON.IN,
             or the chdir flag must be turned on. This is an artifact of OpenFAST looking for DISCON.IN
             in the folder that it is called from. 
@@ -107,17 +96,8 @@ class FAST_IO():
         fignum: int, optional
             Define figure number. Note: Should only be used when plotting a singular case. 
         '''
-        # Plot cases
-        for case in cases.keys():
-            # channels to plot
-            plot_list = cases[case]
-             # instantiate plot and legend
-            fig, axes = plt.subplots(len(plot_list),1, sharex=True,num=fignum)
     
-            myleg = []
-            for info, data in zip(allinfo, alldata):
-                # Load desired attribute names for simplicity
-                channels = info['channels']
+    def plot_fast_out(self, cases, fast_dict, showplot=False, fignum=None, xlim=None):
                 # Define time
                 Time = np.ndarray.flatten(data[:,channels.index('Time')])
                 # write legend

--- a/ROSCO_toolbox/utilities.py
+++ b/ROSCO_toolbox/utilities.py
@@ -575,6 +575,45 @@ class FAST_IO():
             data[:, info['channels'].index('Time')]) - tmin
         return data
 
+    def trim_output_dict(self, fast_data, tmin=0, tmax=100000):
+        '''
+        Trim loaded fast output data 
+
+        Parameters
+        ----------
+        info : dict
+            info from load_output containing:
+                - name: filename
+                - description: description of dataset
+                - channels: list of channel names
+                - attribute_units: list of attribute units
+        fast_data : ndarray
+            List of all output data from load_outputinfo (list containing dictionaries)
+        tmin : float, optional
+            start time
+        tmax : float, optional
+            end time
+        
+        Returns
+        -------
+        data : ndarray
+            input data ndarray with values trimed to times tmin and tmax
+        '''
+        # initial time array and associated index
+        for fd in fast_data:
+            # time_init = np.ndarray.flatten(data[:, fast_dict['channels'].index('Time')])
+            T0ind = np.searchsorted(fd['Time'], tmin)
+            Tfind = np.searchsorted(fd['Time'], tmax) + 1
+            # tvals = [time.tolist() for time in time_init[Tinds]]
+
+            # Remove all vales in data where time is not in desired range
+            for key in fd.keys():
+                if key.lower() == 'time':
+                    fd['Time'] = fd['Time'][T0ind:Tfind] - fd['Time'][T0ind]
+                elif key != 'meta':
+                    fd[key] = fd[key][T0ind:Tfind]
+
+            return fast_dict
 
 class FileProcessing():
     """

--- a/ROSCO_toolbox/utilities.py
+++ b/ROSCO_toolbox/utilities.py
@@ -343,6 +343,7 @@ class FAST_IO():
         info = []
         fastout_dict = {}
         fastout_dict['filenames'] = []
+        fastout_dict['meta'] = []
         for i, filename in enumerate(filenames):
             assert os.path.isfile(filename), "File, %s, does not exists" % filename
             with open(filename, 'r') as f:
@@ -359,14 +360,16 @@ class FAST_IO():
                     data_ascii = self.trim_output(info_ascii, data_ascii, tmin, tmax)
                     data.append(data_ascii)
                     info.append(info_ascii)
-        
-                if output_dict:
-                    for channel in info[-1]['channels']:
-                        if channel not in fastout_dict.keys():
-                            fastout_dict[channel] = []
-                        fastout_dict[channel].append(
-                            np.array(data[-1][:, info[-1]['channels'].index(channel)]).tolist())
-                    fastout_dict['filenames'].append(filename)
+
+            if output_dict:
+                for channel in info[i]['channels']:
+                    if channel not in fastout_dict.keys():
+                        fastout_dict[channel] = [[]]*(i)
+                    fastout_dict[channel].append(
+                        np.array(data[i][:, info[i]['channels'].index(channel)]))
+                fastout_dict['filenames'].append(filename)
+                fastout_dict['meta'].append(info[i])
+
         if output_dict:
             return info, data, fastout_dict
         else:

--- a/ROSCO_toolbox/utilities.py
+++ b/ROSCO_toolbox/utilities.py
@@ -144,8 +144,74 @@ class FAST_IO():
             if xlim:
                 plt.xlim(xlim)
         if showplot:
-            plt.draw()
+            plt.show()
 
+    def plot_fast_out_dict(self, cases, fast_dict, showplot=False, fignum=None, xlim=None):
+        '''
+        Plots OpenFAST outputs for desired channels
+
+        Parameters:
+        -----------
+        cases : dict
+            Dictionary of lists containing desired outputs
+        fast_dict : dict
+            Dictionary of OpenFAST output information, output from load_output
+        showplot: bool, optional
+            Show the plot
+        fignum: int, optional
+            Define figure number. Note: Should only be used when plotting a singular case. 
+        '''
+        figlist = []
+        axeslist = []
+        # Plot cases
+        for case in cases.keys():
+            # channels to plot
+            channels = cases[case]
+            # instantiate plot and legend
+            fig, axes = plt.subplots(len(channels), 1, sharex=True, num=fignum)
+
+            myleg = []
+            for fidx, Time in enumerate(fast_dict['Time']):
+                # write legend
+                myleg.append(fast_dict['meta'][fidx]['name'])
+                if len(channels) > 1:  # Multiple channels
+                    for axj, channel in zip(axes, channels):
+                        try:
+                            # plot
+                            axj.plot(Time, fast_dict[channel][fidx])
+                            # label
+                            unit_idx = fast_dict['meta'][fidx]['channels'].index(channel)
+                            axj.set(ylabel='{:^} \n ({:^})'.format(
+                                channel, 
+                                fast_dict['meta'][fidx]['attribute_units'][unit_idx]))
+                            axj.grid(True)
+                        except:
+                            print('{} is not available as an output channel.'.format(channel))
+                    axes[0].set_title(case)
+                else:                   # Single channel
+                    try:
+                        # plot
+                        axes.plot(Time, fast_dict[channel][fidx])
+                        # label
+                        axes.set(ylabel=channel[0])
+                        axes.grid(True)
+                        axes.set_title(case)
+                    except:
+                        print('{} is not available as an output channel.'.format(channel))
+                plt.legend(myleg, loc='upper center', bbox_to_anchor=(
+                    0.5, 0.0), borderaxespad=2, ncol=len(fast_dict['filenames']))
+            
+            figlist.append(fig)
+            axeslist.append(axes)
+            
+            if xlim:
+                plt.xlim(xlim)
+            
+        if showplot:
+            plt.show()
+
+
+        return figlist, axeslist
         
     def load_output(self, filenames, output_dict=False, tmin=0, tmax=10000):
         """Load a FAST binary or ascii output file

--- a/ROSCO_toolbox/utilities.py
+++ b/ROSCO_toolbox/utilities.py
@@ -90,7 +90,7 @@ class FAST_IO():
             os.system('{} {}'.format(fastcall, os.path.join(fast_dir,fastfile)))
             print('OpenFAST simulation complete. ')
 
-    def plot_fast_out(self, cases, allinfo, alldata, showplot=True, fignum=None, xlim=None):
+    def plot_fast_out(self, cases, allinfo, alldata, showplot=False, fignum=None, xlim=None):
         '''
         Plots OpenFAST outputs for desired channels
 


### PR DESCRIPTION
Large updates for OpenFAST post processing functions in `Utilities.py`.  Mostly, this is changing the format for the data handlingThis should _maybe_ be a version incrementation given the changes in the API for loading and plotting FAST output data, but we'll save that for another day and just increment this as a "feature add".

A brief overview of major changes:
- `load_output` is renamed to `load_fast_out`
- `load_fast_out` now writes out a list of dictionaries containing openfast data, where each list item corresponds to an OpenFAST output case. 
- All plotting functions were moved to a class `FAST_plots`
- `plot_fast_out` only receives the output from `load_fast_out` for the OpenFAST data to plot
- `plot_spectral` is included for a number of frequency-domain based plotting capabilities
- `trim_fast_out` is modified to only modify data passed in the new dictionary-based structure
- some verbosity flags have been included 


