### PR TITLE
Interpolation bug fixes

### DIFF
--- a/Examples/example_07.py
+++ b/Examples/example_07.py
@@ -45,11 +45,12 @@ turbine.load_from_fast(path_params['FAST_InputFile'],path_params['FAST_directory
 controller.tune_controller(turbine)
 
 # Plot minimum pitch schedule
-plt.plot(controller.v, controller.pitch_op,label='Steady State Operation')
-plt.plot(controller.v, controller.ps_min_bld_pitch, label='Minimum Pitch Schedule')
-plt.legend()
-plt.xlabel('Wind speed (m/s)')
-plt.ylabel('Blade pitch (rad)')
+fig, ax = plt.subplots(1,1)
+ax.plot(controller.v, controller.pitch_op,label='Steady State Operation')
+ax.plot(controller.v, controller.ps_min_bld_pitch, label='Minimum Pitch Schedule')
+ax.legend()
+ax.set_xlabel('Wind speed (m/s)')
+ax.set_ylabel('Blade pitch (rad)')
 
 if False:
   plt.show()

--- a/ROSCO_toolbox/controller.py
+++ b/ROSCO_toolbox/controller.py
@@ -158,7 +158,7 @@ class Controller():
         TSR_rated = rated_rotor_speed*R/turbine.v_rated  # TSR at rated
 
         # separate wind speeds by operation regions
-        v_below_rated = np.linspace(turbine.v_min,turbine.v_rated, num=30)             # below rated
+        v_below_rated = np.linspace(turbine.v_min,turbine.v_rated, num=30)[:-1]             # below rated
         v_above_rated = np.linspace(turbine.v_rated,turbine.v_max, num=30)             # above rated
         v = np.concatenate((v_below_rated, v_above_rated))
 

--- a/ROSCO_toolbox/controller.py
+++ b/ROSCO_toolbox/controller.py
@@ -479,7 +479,7 @@ class ControllerBlocks():
             else:
                 Ct_max[i] = np.minimum( np.max(Ct_tsr), Ct_max[i])
             # Define minimum pitch angle
-            f_pitch_min = interpolate.interp1d(Ct_tsr, turbine.pitch_initial_rad, kind='cubic', bounds_error=False, fill_value=(turbine.pitch_initial_rad[0],turbine.pitch_initial_rad[-1]))
+            f_pitch_min = interpolate.interp1d(Ct_tsr, turbine.pitch_initial_rad, kind='linear', bounds_error=False, fill_value=(turbine.pitch_initial_rad[0],turbine.pitch_initial_rad[-1]))
             pitch_min[i] = max(controller.min_pitch, f_pitch_min(Ct_max[i]))
 
         controller.ps_min_bld_pitch = pitch_min

--- a/ROSCO_toolbox/controller.py
+++ b/ROSCO_toolbox/controller.py
@@ -189,7 +189,8 @@ class Controller():
             # Find pitch angle as a function of expected operating CP for each TSR
             Cp_TSR = np.ndarray.flatten(turbine.Cp.interp_surface(turbine.pitch_initial_rad, TSR_op[i]))     # all Cp values for a given tsr
             Cp_op[i] = np.clip(Cp_op[i], np.min(Cp_TSR), np.max(Cp_TSR))        # saturate Cp values to be on Cp surface
-            f_cp_pitch = interpolate.interp1d(Cp_TSR,pitch_initial_rad)         # interpolate function for Cp(tsr) values
+            Cp_maxidx = Cp_TSR.argmax()                                                                 # Find maximum Cp value for this TSR
+            f_cp_pitch = interpolate.interp1d(Cp_TSR[Cp_maxidx:],pitch_initial_rad[Cp_maxidx:])         # interpolate function for Cp(tsr) values
             # expected operation blade pitch values
             if v[i] <= turbine.v_rated and isinstance(self.min_pitch, float): # Below rated & defined min_pitch
                 pitch_op[i] = min(self.min_pitch, f_cp_pitch(Cp_op[i]))


### PR DESCRIPTION
This fixes some bugs with the interpolation of Cp and Ct surfaces.

When calculating the the expected pitch angle trajectory, the specifics of the Cp surface can cause a non-monotonic interpolation function. The logic says "For a specific TSR, what is the blade pitch angle that gives a Cp of x". If the Cp's for a specific TSR are not monotonic, errors can be caused. 65c4020 fixes this by only allowing blade pitch angles that occur "above" the maximum Cp for a specific TSR - this provides the expected results.

9e89ef8 sets the Ct surface interpolation to linear instead of cubic - this is giving cleaner results