### PR TITLE
Update control interface: add nacelle IMU, method to kill discon

### DIFF
--- a/.github/workflows/CI_rosco-toolbox.yml
+++ b/.github/workflows/CI_rosco-toolbox.yml
@@ -96,7 +96,7 @@ jobs:
       # Install OpenFAST
       - name: Install OpenFAST
         run: |
-          conda install openfast
+          conda install openfast==2.5.0
           
       # Run examples
       - name: Run examples


### PR DESCRIPTION
This is a small update to enable more features in the control interface.  It passed example_05.py locally...let's try out the CI!

Minor Changes:
- Set openfast install to 2.5.0 until there's a release on github and we can update input files in `TestCases/`